### PR TITLE
Fix server startup directory creation logic

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,7 @@ import httpx
 import asyncio
 import subprocess
 
-from app.core.config import settings
+from app.core.config import settings, ensure_app_directories
 
 # Configure logging
 logging.basicConfig(
@@ -40,6 +40,14 @@ async def lifespan(app: FastAPI):
     global scheduler_service
     
     # Startup
+    # Ensure all required directories exist before any database operations
+    try:
+        ensure_app_directories()
+        logging.info("Directory initialization completed successfully")
+    except Exception as e:
+        logging.error(f"Failed to initialize directories: {e}")
+        raise  # Critical error, should stop application startup
+    
     try:
         async with engine.begin() as conn:
             # Create tables if they don't exist


### PR DESCRIPTION
- Add comprehensive ensure_app_directories() function that creates all required directories
- Include explicit database directory creation (/app/app_data/database)
- Add proper error handling with detailed logging for permission issues
- Call directory initialization early in application startup before database operations
- Replace single recordings directory creation with full directory structure setup

This fixes the critical issue where fresh deployments would fail due to missing database directory, preventing SQLite database creation.

Resolves: #9

🤖 Generated with [Claude Code](https://claude.ai/code)