### PR TITLE
Replace Basic Auth with Standard JSON Login Pattern

### DIFF
--- a/backend/app/api/v1/endpoints/auth.py
+++ b/backend/app/api/v1/endpoints/auth.py
@@ -2,13 +2,11 @@
 Authentication API endpoints
 """
 from fastapi import APIRouter, Depends, HTTPException, status, Header
-from fastapi.security import HTTPBasic, HTTPBasicCredentials
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import select
 from pydantic import BaseModel
 from typing import Optional
 import hashlib
-import secrets
 
 from app.database.database import get_db
 from app.database.models import User
@@ -16,7 +14,6 @@ from app.core.config import settings
 from app.core.jwt import create_user_token, blacklist_token, clear_user_tokens, get_current_user_from_token
 
 router = APIRouter()
-security = HTTPBasic()
 
 class LoginRequest(BaseModel):
     username: str
@@ -37,11 +34,11 @@ class MessageResponse(BaseModel):
 
 @router.post("/login", response_model=LoginResponse)
 async def login(
-    credentials: HTTPBasicCredentials = Depends(security),
+    credentials: LoginRequest,
     db: AsyncSession = Depends(get_db)
 ):
     """
-    Login with Basic Auth credentials and receive JWT token
+    Login with JSON credentials and receive JWT token
     """
     # Get user from database first
     result = await db.execute(
@@ -121,8 +118,7 @@ async def login(
     
     raise HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Incorrect username or password",
-        headers={"WWW-Authenticate": "Basic"},
+        detail="Incorrect username or password"
     )
 
 


### PR DESCRIPTION
## Summary
Improves authentication system by replacing HTTP Basic Auth with standard JSON login pattern for better API consistency and developer experience.

## Changes Made
- ✅ Remove `HTTPBasicCredentials` dependency from login endpoint
- ✅ Accept `LoginRequest` JSON payload directly (`{"username": "string", "password": "string"}`)
- ✅ Clean up unused imports (`HTTPBasic`, `HTTPBasicCredentials`, `secrets`)
- ✅ Maintain existing JWT token response format
- ✅ Frontend API client already supports JSON payload (no changes needed)

## Testing
- ✅ Manual testing with `curl` confirms JSON login works correctly
- ✅ Returns proper JWT token with user information
- ✅ Server starts without errors

## Impact
- **Better API Design**: Standard RESTful JSON endpoints
- **Improved DX**: No more Basic Auth header construction needed
- **Consistency**: All endpoints now use JSON payloads
- **Future-Proof**: Easier to extend with features like OAuth2, refresh tokens

## Fixes
Closes #8

🤖 Generated with [Claude Code](https://claude.ai/code)