### PR TITLE
fix: inject version from Git tags during Docker build

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -56,6 +56,8 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            VERSION=${{ github.ref_name }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,12 @@
 # Stage 1: Frontend Build
 FROM node:20-alpine AS frontend-builder
+
+# Accept version as build argument
+ARG VERSION=dev
+
+# Set environment variable for Next.js build
+ENV NEXT_PUBLIC_APP_VERSION=${VERSION}
+
 WORKDIR /app/frontend
 
 # Copy package files
@@ -10,8 +17,11 @@ RUN npm install
 COPY frontend/ .
 RUN npm run build
 
-# Stage 2: Backend Production  
+# Stage 2: Backend Production
 FROM python:3.10-slim
+
+# Accept version as build argument
+ARG VERSION=dev
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
@@ -50,6 +60,7 @@ RUN mkdir -p /app/app_data/{database,recordings,logs,config} \
 USER appuser
 
 # Set environment variables
+ENV VERSION=${VERSION}
 ENV APP_DATA_DIR=/app/app_data
 ENV PYTHONPATH=/app
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
# Pull Request

## Summary
Fixes the Docker build process to properly inject version information from Git tags without relying on .env files. This ensures that both frontend and backend applications display the correct version when deployed via Docker.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation update
- [ ] 🔧 Refactoring (no functional changes, no api changes)
- [ ] 🎨 Style changes (formatting, missing semi colons, etc)
- [ ] ⚡ Performance improvement

## Related Issues
Resolves the core issue with Docker builds not having proper version information

## Changes Made
- Added VERSION build argument to both frontend and backend Docker stages
- Set NEXT_PUBLIC_APP_VERSION environment variable in frontend stage for Next.js build-time injection
- Set VERSION environment variable in backend stage for Python runtime access
- Updated docker-release.yml workflow to pass github.ref_name as VERSION build argument
- Eliminated dependency on .env files for version information in Docker builds

## Testing
- [x] Manual testing completed (Docker build logic verified)
- [x] All existing features still work
- [ ] Unit tests pass (no changes to test logic)
- [ ] Backend/Frontend integration tested (version display needs verification)
- [x] Docker build succeeds (core functionality of this fix)

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Additional Notes
This is the correct solution for version management in Docker builds. The previous approach of trying to manage .env files was fundamentally flawed since those files should remain in .gitignore for security reasons. This approach uses Docker's build argument system to inject version information at build time, which is the standard practice for containerized applications.